### PR TITLE
If no ref is given, always update to newest commit

### DIFF
--- a/lib/bosh/workspace/release.rb
+++ b/lib/bosh/workspace/release.rb
@@ -11,7 +11,7 @@ module Bosh::Workspace
     end
 
     def update_repo
-      repo.checkout ref || version_ref, strategy: :force
+      repo.checkout ref || repo.head.target_id, strategy: :force
     end
 
     def manifest_file

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -78,7 +78,7 @@ describe Bosh::Workspace::Release do
       let(:version) { "12" }
 
       it "raises an error" do
-        expect { release.update_repo }.
+        expect { release.version }.
           to raise_error(/Could not find version/)
       end
     end


### PR DESCRIPTION
Currently, the repo is updated to the revision of the last commit in the newestrelease yml, e.g. the last commit to foo-11.yml, if that is the newest one in the repo. It should be update to the last commit instead, referenced by repo.head.target_id.

**Note** this changes the validation behavior a bit, errors are thrown once a version is accessed which doesn't exist, not immediately on checkout of the repo