### PR TITLE
Add possibility to use bosh-templates for user stubs

### DIFF
--- a/bosh-workspace.gemspec
+++ b/bosh-workspace.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_runtime_dependency "bosh_cli",  ">= 1.2905.0"
-  spec.add_runtime_dependency "bosh_common",  ">= 1.2905.0"
+  spec.add_runtime_dependency "bosh_cli", ">= 1.2905.0"
+  spec.add_runtime_dependency "bosh_common", ">= 1.2905.0"
+  spec.add_runtime_dependency "bosh-template", ">= 1.2905.0"
   spec.add_runtime_dependency "semi_semantic", "~> 1.1.0"
   spec.add_runtime_dependency "membrane", "~> 1.1.0"
   spec.add_runtime_dependency "hashdiff", "~> 0.2.1"

--- a/lib/bosh/workspace.rb
+++ b/lib/bosh/workspace.rb
@@ -6,6 +6,7 @@ require "rugged"
 require "hashdiff"
 require "cli/core_ext"
 require "cli/validation"
+require "bosh/template/renderer"
 
 require "bosh/workspace/helpers/spiff_helper"
 require "bosh/workspace/helpers/project_deployment_helper"

--- a/lib/bosh/workspace/project_deployment.rb
+++ b/lib/bosh/workspace/project_deployment.rb
@@ -36,8 +36,6 @@ module Bosh::Workspace
     def stub
       return @stub unless @stub.nil?
       stub_file = File.join(file_dirname.gsub(/\/deployments\/?$/, ''), 'stubs', file_basename)
-      puts "stub_file: #{stub_file}"
-      puts "stub: #{Psych.load(File.read(stub_file))}" if File.exist?(stub_file)
       @stub = File.exist?(stub_file) ? Psych.load(File.read(stub_file)) : {}
     end
 

--- a/lib/bosh/workspace/project_deployment.rb
+++ b/lib/bosh/workspace/project_deployment.rb
@@ -29,9 +29,7 @@ module Bosh::Workspace
 
     def manifest
       return @manifest unless @manifest.nil?
-      puts stub.to_json
       renderer = Bosh::Template::Renderer.new(context: stub.to_json)
-      puts renderer.inspect
       @manifest = Psych.load(renderer.render(file))
     end
 

--- a/lib/bosh/workspace/project_deployment.rb
+++ b/lib/bosh/workspace/project_deployment.rb
@@ -35,7 +35,7 @@ module Bosh::Workspace
 
     def stub
       return @stub unless @stub.nil?
-      stub_file = File.join(file_dirname.gsub(/\/deployments\/?$/, ''), 'stubs', file_basename)
+      stub_file = File.expand_path(File.join(file_dirname, "../stubs", file_basename))
       @stub = File.exist?(stub_file) ? Psych.load(File.read(stub_file)) : {}
     end
 

--- a/spec/assets/manifests-repo/deployments/foo.yml
+++ b/spec/assets/manifests-repo/deployments/foo.yml
@@ -3,3 +3,4 @@ name: foo
 templates:
   - foo/bar.yml
 meta: {}
+stub_value: <%= p('stub.value') %>

--- a/spec/assets/manifests-repo/stubs/foo.yml
+++ b/spec/assets/manifests-repo/stubs/foo.yml
@@ -1,0 +1,4 @@
+---
+properties:
+  stub:
+    value: value

--- a/spec/helpers/project_deployment_helper_spec.rb
+++ b/spec/helpers/project_deployment_helper_spec.rb
@@ -23,7 +23,7 @@ describe Bosh::Workspace::ProjectDeploymentHelper do
   describe "project_deployment?" do
     subject { project_deployment_helper.project_deployment? }
     let(:project_deployment_helper) { ProjectDeploymentHelperTester.new(director, deployment) }
-    let(:deployment) { File.join work_dir, deployment_path }
+    let(:deployment) { File.join(work_dir, deployment_path) }
 
     context "deployment" do
       context "without associated project deployment" do

--- a/spec/project_deployment_spec.rb
+++ b/spec/project_deployment_spec.rb
@@ -1,7 +1,8 @@
 module Bosh::Workspace
   describe ProjectDeployment do
     subject { Bosh::Workspace::ProjectDeployment.new manifest_file }
-    let(:manifest_file) { get_tmp_file_path(ruby_code + manifest.to_yaml, file_name) }
+    let(:manifest_content) { ruby_code + manifest.to_yaml }
+    let(:manifest_file) { get_tmp_file_path(manifest_content, file_name) }
     let(:file_name) { "foo.yml" }
     let(:manifest) { :manifest }
     let(:ruby_code) { "<% ruby_var=42 %>" }
@@ -12,6 +13,39 @@ module Bosh::Workspace
           allow(File).to receive(:exist?).with(manifest_file).and_return(false)
         end
         it { expect { subject }.to raise_error(/deployment file.+not exist/i) }
+      end
+    end
+
+    describe '#stub' do
+      let(:stub_file) { /stubs\/#{file_name}/ }
+      let(:stub_content) { "---\nproperties:\n  stub:\n    value: litmus\n" }
+      before do
+        allow(File).to receive(:exist?).with(manifest_file).and_return(true)
+      end
+
+      context 'with stub file' do
+        let(:manifest) { { 'director_uuid' => '<%= p("stub.value") %>' } }
+        before do
+          allow(File).to receive(:exist?).with(stub_file).and_return(true)
+          allow(File).to receive(:read).with(stub_file).and_return(stub_content)
+          allow(File).to receive(:read).with(manifest_file).and_return(manifest_content)
+        end
+
+        it 'renders manifest using bosh-template' do
+          expect(subject.director_uuid).to eq('litmus')
+        end
+      end
+
+      context 'without stub file' do
+        let(:manifest) { { 'director_uuid' => 'litmus' } }
+
+        before do
+          allow(File).to receive(:exist?).with(/stubs\/#{file_name}/).and_return(false)
+        end
+
+        it 'renders manifest without bosh-template' do
+          expect(subject.director_uuid).to eq('litmus')
+        end
       end
     end
 


### PR DESCRIPTION
The main idea is that your workspace should have `stubs` folder for secrets that you don't want to share with anyone. When you call deploy command the resulting manifest will be made of the one you have in `deployments` folder and some stub from `stubs` folder. I think that it's ok to find stub file using the same name as deployment name. If stub file does not exist, nothing will happen and template will processed as erb template as it was before.

Using this approach allows us to have better control on the secrets in workspace repo.