### PR TITLE
Cache final release tarballs locally

### DIFF
--- a/lib/bosh/cli/commands/prepare.rb
+++ b/lib/bosh/cli/commands/prepare.rb
@@ -82,6 +82,7 @@ module Bosh::Cli::Command
 
     def cached_stemcell_upload(stemcell)
       unless stemcell.downloaded?
+        err "Stemcell not available offline: #{stemcell.file_name}" if offline?
         say "Downloading '#{stemcell.name_version.make_green}'"
         stemcell_download(stemcell.file_name)
       end

--- a/lib/bosh/cli/commands/prepare.rb
+++ b/lib/bosh/cli/commands/prepare.rb
@@ -58,7 +58,7 @@ module Bosh::Cli::Command
         say "Skipping upload"
       elsif release.url
         say "Uploading '#{release.url}'"
-        release_upload(release.url, release.release_dir)
+        release_upload_from_url(release.url)
       else
         say "Uploading '#{release.name_version.make_green}'"
         release_upload(release.manifest_file, release.release_dir)

--- a/lib/bosh/workspace/helpers/project_deployment_helper.rb
+++ b/lib/bosh/workspace/helpers/project_deployment_helper.rb
@@ -46,7 +46,7 @@ module Bosh::Workspace
 
       say("Generating deployment manifest")
       ManifestBuilder.build(project_deployment, work_dir)
-      
+
       if domain_name = project_deployment.domain_name
         say("Transforming to dynamic networking (dns)")
         DnsHelper.transform(project_deployment.merged_file, domain_name)
@@ -55,6 +55,14 @@ module Bosh::Workspace
 
     def resolve_director_uuid
       use_targeted_director_uuid if director_uuid_current?
+    end
+
+    def offline!
+      @offline = true
+    end
+
+    def offline?
+      @offline
     end
 
     private

--- a/spec/commands/prepare_spec.rb
+++ b/spec/commands/prepare_spec.rb
@@ -77,8 +77,8 @@ describe Bosh::Cli::Command::Prepare do
           let(:url) { "bosh.io/foo/bar.tgz" }
 
           it "does uploads a remote release" do
-            expect(command).to receive(:release_upload)
-              .with(release.url, release.release_dir)
+            expect(command).to receive(:release_upload_from_url)
+              .with(release.url)
             command.prepare
           end
         end

--- a/spec/commands/prepare_spec.rb
+++ b/spec/commands/prepare_spec.rb
@@ -128,20 +128,29 @@ describe Bosh::Cli::Command::Prepare do
         context "stemcell downloaded" do
           let(:stemcell_downloaded) { true }
 
-          it "does not upload the stemcell" do
+          it "uploads the already downloaded stemcell" do
             expect(command).to_not receive(:stemcell_download)
             expect(command).to receive(:stemcell_upload).with(stemcell.file)
             command.prepare
           end
         end
 
-        context "stemcell downloaded" do
+        context "when stemcell not downloaded" do
           let(:stemcell_downloaded) { false }
 
-          it "does not upload the stemcell" do
+          it "downloads and uploads the stemcell" do
             expect(command).to receive(:stemcell_download).with(stemcell.file_name)
             expect(command).to receive(:stemcell_upload).with(stemcell.file)
             command.prepare
+          end
+
+          context "while being offline" do
+            before { command.offline! }
+
+            it "raises an error" do
+              expect(command).to_not receive(:stemcell_download)
+              expect{command.prepare}.to raise_error /not available offline/
+            end
           end
         end
       end

--- a/spec/helpers/project_deployment_helper_spec.rb
+++ b/spec/helpers/project_deployment_helper_spec.rb
@@ -206,4 +206,15 @@ describe Bosh::Workspace::ProjectDeploymentHelper do
       end
     end
   end
+
+  describe "#offline!" do
+    it "enforces offline mode" do
+      subject.offline!
+      expect(subject.offline?).to eq(true)
+    end
+
+    it "defaults to online" do
+      expect(subject.offline?).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
This PR finishes the `bosh prepare deployment --local` story.
It properly checks if the required files are available locally and raise errors otherwise.