### PR TITLE
Use recursive_merge instead of Bosh::Template::Renderer for stubs

### DIFF
--- a/bosh-workspace.gemspec
+++ b/bosh-workspace.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "bosh_cli", ">= 1.2905.0"
   spec.add_runtime_dependency "bosh_common", ">= 1.2905.0"
-  spec.add_runtime_dependency "bosh-template", ">= 1.2905.0"
   spec.add_runtime_dependency "semi_semantic", "~> 1.1.0"
   spec.add_runtime_dependency "membrane", "~> 1.1.0"
   spec.add_runtime_dependency "hashdiff", "~> 0.2.1"

--- a/spec/assets/manifests-repo/deployments/foo.yml
+++ b/spec/assets/manifests-repo/deployments/foo.yml
@@ -3,4 +3,3 @@ name: foo
 templates:
   - foo/bar.yml
 meta: {}
-stub_value: <%= p('stub.value') %>

--- a/spec/assets/manifests-repo/stubs/foo.yml
+++ b/spec/assets/manifests-repo/stubs/foo.yml
@@ -1,4 +1,4 @@
 ---
-properties:
+meta:
   stub:
     value: value

--- a/spec/project_deployment_spec.rb
+++ b/spec/project_deployment_spec.rb
@@ -24,24 +24,31 @@ module Bosh::Workspace
       end
 
       context 'with stub file' do
-        let(:manifest) { { 'director_uuid' => '<%= p("stub.value") %>' } }
-        let(:stub_content) { "---\nproperties:\n  stub:\n    value: litmus\n" }
+        let(:manifest) { { 'director_uuid' => 'DIRECTOR_UUID' } }
+        let(:stub_content) do
+          {
+            'name' => 'bar',
+            'director_uuid' => 'foo-uuid',
+            'meta' => { 'foo' => 'bar' }
+          }.to_yaml
+        end
+
         before do
           allow(File).to receive(:exist?).with(stub_file).and_return(true)
           allow(File).to receive(:read).with(stub_file).and_return(stub_content)
         end
 
-        it 'reads manifest using bosh-template render' do
-          expect(subject.manifest['director_uuid']).to eq('litmus')
+        it 'merges stub with manifest' do
+          expect(subject.manifest['director_uuid']).to eq('foo-uuid')
         end
 
-        context 'with missing properties' do
-          let(:stub_content) { "---\nproperties:\n  stub: litmus\n" }
-          it 'raises error' do
-            expect { subject.manifest }.to raise_error /Can't find property/
+        context 'stub with releases' do
+          let(:stub_content) { { 'releases' => [] }.to_yaml }
+
+          it 'raises an error' do
+            expect{ subject.manifest }.to raise_error /releases.+not allowed/
           end
         end
-
       end
 
       context 'without stub file' do


### PR DESCRIPTION
This PR simplifies stub files, by not having to use an intermediate format (erb with 'p('foo') helpers).
It allow you to create a yaml stub file which can be used to inject `name`, `director_uuid` and `meta`.

cc @allomov