### PR TITLE
Remove require pry gem from workspace/release to avoid errors

### DIFF
--- a/lib/bosh/workspace/release.rb
+++ b/lib/bosh/workspace/release.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module Bosh::Workspace
   class Release
     REFSPEC = ['HEAD:refs/remotes/origin/HEAD']


### PR DESCRIPTION
Hey, @rkoster.

I needed to remove this requirement to avoid error `can not find file`.