### PR TITLE
Stemcell upload

### DIFF
--- a/lib/bosh/cli/commands/prepare.rb
+++ b/lib/bosh/cli/commands/prepare.rb
@@ -81,13 +81,9 @@ module Bosh::Cli::Command
     end
 
     def cached_stemcell_upload(stemcell)
-      unless stemcell.downloaded?
-        err "Stemcell not available offline: #{stemcell.file_name}" if offline?
-        say "Downloading '#{stemcell.name_version.make_green}'"
-        stemcell_download(stemcell.file_name)
-      end
       say "Uploading '#{stemcell.name_version.make_green}'"
-      stemcell_upload(stemcell.file)
+      stemcell_upload_url("https://bosh.io/d/stemcells/#{stemcell.name}?v=#{stemcell.version}")
     end
+
   end
 end

--- a/lib/bosh/workspace/helpers/stemcell_helper.rb
+++ b/lib/bosh/workspace/helpers/stemcell_helper.rb
@@ -16,6 +16,12 @@ module Bosh::Workspace
       stemcell_cmd.upload(stemcell_file)
     end
 
+    def stemcell_upload_url(stemcell_url)
+      say "Uploading stemcell from URL '#{stemcell_url}'"
+      nl
+      stemcell_cmd.upload(stemcell_url)
+    end
+
     def stemcell_uploaded?(name, version)
       existing = director.list_stemcells.select do |sc|
         sc['name'] == name && sc['version'] == version.to_s

--- a/lib/bosh/workspace/helpers/stemcell_helper.rb
+++ b/lib/bosh/workspace/helpers/stemcell_helper.rb
@@ -2,20 +2,6 @@ module Bosh::Workspace
   module StemcellHelper
     include ProjectDeploymentHelper
 
-    def stemcell_download(stemcell_name)
-      Dir.chdir(stemcells_dir) do
-        say "Downloading stemcell '#{stemcell_name}'"
-        nl
-        stemcell_cmd.download_public(stemcell_name)
-      end
-    end
-
-    def stemcell_upload(stemcell_file)
-      say "Uploading stemcell '#{File.basename(stemcell_file)}'"
-      nl
-      stemcell_cmd.upload(stemcell_file)
-    end
-
     def stemcell_upload_url(stemcell_url)
       say "Uploading stemcell from URL '#{stemcell_url}'"
       nl
@@ -30,15 +16,9 @@ module Bosh::Workspace
       !existing.empty? 
     end
 
-    def stemcells_dir
-      @stemcells_dir ||= begin
-        FileUtils.mkdir_p(File.join(work_dir, ".stemcells")).first
-      end
-    end
-
     def project_deployment_stemcells
       @stemcells ||= begin
-        project_deployment.stemcells.map { |s| Stemcell.new(s, stemcells_dir) }
+        project_deployment.stemcells.map { |s| Stemcell.new(s) }
       end
     end
 

--- a/lib/bosh/workspace/stemcell.rb
+++ b/lib/bosh/workspace/stemcell.rb
@@ -1,25 +1,14 @@
 module Bosh::Workspace
   class Stemcell
-    attr_reader :name, :version, :file
+    attr_reader :name, :version
 
-    def initialize(stemcell, stemcells_dir)
+    def initialize(stemcell)
       @name = stemcell["name"]
       @version = stemcell["version"]
-      @light = stemcell["light"]
-      @file = File.join(stemcells_dir, file_name)
     end
 
     def name_version
       "#{name}/#{version}"
-    end
-
-    def file_name
-      prefix = @light ? 'light-' : ''
-      name.gsub(/^bosh-/, "#{prefix}bosh-stemcell-#{version}-") + '.tgz'
-    end
-
-    def downloaded?
-      File.exist? file
     end
   end
 end

--- a/spec/commands/prepare_spec.rb
+++ b/spec/commands/prepare_spec.rb
@@ -12,8 +12,7 @@ describe Bosh::Cli::Command::Prepare do
     end
     let(:stemcell) do
       instance_double("Bosh::Workspace::Stemcell",
-        name: "bar", version: "2", name_version: "bar/2",
-        file: ".stemcesll/bar-2.tgz", file_name: "bar-2.tgz")
+        name: "bar", version: "2", name_version: "bar/2")
     end
 
     before do
@@ -111,39 +110,17 @@ describe Bosh::Cli::Command::Prepare do
         let(:stemcell_uploaded) { true }
 
         it "does not upload the stemcell" do
-          expect(command).to_not receive(:stemcell_download)
-          expect(command).to_not receive(:stemcell_upload)
+          expect(command).to_not receive(:cached_stemcell_upload)
           command.prepare
         end
       end
 
       context "stemcell not uploaded" do
         let(:stemcell_uploaded) { false }
-
-        before do
-          allow(stemcell).to receive(:downloaded?)
-          .and_return(stemcell_downloaded)
-        end
-
-        context "stemcell downloaded" do
-          let(:stemcell_downloaded) { true }
-
-          it "uploads the already downloaded stemcell" do
-            expect(command).to_not receive(:stemcell_download)
+          it "uploads the stemcell" do
             expect(command).to receive(:stemcell_upload_url).with("https://bosh.io/d/stemcells/#{stemcell.name}?v=#{stemcell.version}")
             command.prepare
           end
-        end
-
-        context "when stemcell not downloaded" do
-          let(:stemcell_downloaded) { false }
-
-          it "downloads and uploads the stemcell" do
-            expect(command).to receive(:stemcell_upload_url).with("https://bosh.io/d/stemcells/#{stemcell.name}?v=#{stemcell.version}")
-            command.prepare
-          end
-
-        end
       end
     end
   end

--- a/spec/commands/prepare_spec.rb
+++ b/spec/commands/prepare_spec.rb
@@ -17,7 +17,7 @@ describe Bosh::Cli::Command::Prepare do
     end
 
     before do
-      allow(command).to receive(:require_project_deployment)
+      allow(command).to receive(:rquire_project_deployment)
       allow(command).to receive(:auth_required)
       allow(command).to receive(:project_deployment_releases)
         .and_return(releases)
@@ -130,7 +130,7 @@ describe Bosh::Cli::Command::Prepare do
 
           it "uploads the already downloaded stemcell" do
             expect(command).to_not receive(:stemcell_download)
-            expect(command).to receive(:stemcell_upload).with(stemcell.file)
+            expect(command).to receive(:stemcell_upload_url).with("https://bosh.io/d/stemcells/#{stemcell.name}?v=#{stemcell.version}")
             command.prepare
           end
         end
@@ -139,19 +139,10 @@ describe Bosh::Cli::Command::Prepare do
           let(:stemcell_downloaded) { false }
 
           it "downloads and uploads the stemcell" do
-            expect(command).to receive(:stemcell_download).with(stemcell.file_name)
-            expect(command).to receive(:stemcell_upload).with(stemcell.file)
+            expect(command).to receive(:stemcell_upload_url).with("https://bosh.io/d/stemcells/#{stemcell.name}?v=#{stemcell.version}")
             command.prepare
           end
 
-          context "while being offline" do
-            before { command.offline! }
-
-            it "raises an error" do
-              expect(command).to_not receive(:stemcell_download)
-              expect{command.prepare}.to raise_error /not available offline/
-            end
-          end
         end
       end
     end

--- a/spec/helpers/stemcell_helper_spec.rb
+++ b/spec/helpers/stemcell_helper_spec.rb
@@ -22,23 +22,13 @@ describe Bosh::Workspace::StemcellHelper do
         .to receive(:new).and_return(stemcell_cmd)
     end
 
-    describe "#stemcell_download" do
-      let(:name) { "foo" }
-      subject { stemcell_helper.stemcell_download(name) }
 
-      it "downloads stemcell" do
-        expect(Dir).to receive(:chdir).and_yield
-        expect(stemcell_cmd).to receive(:download_public).with(name)
-        subject
-      end
-    end
-
-    describe "#stemcell_upload" do
-      let(:file) { "foo.tgz" }
-      subject { stemcell_helper.stemcell_upload(file) }
+    describe "#stemcell_upload_url" do
+      let(:url) { "http://foo" }
+      subject { stemcell_helper.stemcell_upload_url(url) }
 
       it "uploads stemcell" do
-        expect(stemcell_cmd).to receive(:upload).with(file)
+        expect(stemcell_cmd).to receive(:upload).with(url)
         subject
       end
     end
@@ -62,23 +52,6 @@ describe Bosh::Workspace::StemcellHelper do
     end
   end
 
-  describe "#stemcell_dir" do
-    let(:stemcells_dir) { File.join(work_dir, ".stemcells") }
-    subject { stemcell_helper.stemcells_dir }
-
-    before do
-      expect(FileUtils).to receive(:mkdir_p).once.with(stemcells_dir)
-        .and_return([stemcells_dir])
-    end
-
-    it { should eq stemcells_dir }
-
-    it "memoizes" do
-      subject
-      expect(subject).to eq stemcells_dir
-    end
-  end
-
   describe "#project_deployment_stemcells" do
     subject { stemcell_helper.project_deployment_stemcells }
     let(:stemcell) { instance_double("Bosh::Workspace::Stemcell") }
@@ -93,7 +66,7 @@ describe Bosh::Workspace::StemcellHelper do
 
     it "inits stemcells once" do
       expect(Bosh::Workspace::Stemcell).to receive(:new).twice
-        .with(stemcell_data, /\/.stemcells/).and_return(stemcell)
+        .with(stemcell_data).and_return(stemcell)
       subject
       expect(subject).to eq [stemcell, stemcell]
     end

--- a/spec/stemcell_spec.rb
+++ b/spec/stemcell_spec.rb
@@ -1,61 +1,17 @@
 describe Bosh::Workspace::Stemcell do
-  subject { Bosh::Workspace::Stemcell.new(stemcell, stemcells_dir) }
-  let(:stemcells_dir) { ".stemcells" }
-  let(:stemcell) { { "name" => name, "version" => version, "light" => light } }
+  subject { Bosh::Workspace::Stemcell.new(stemcell) }
+  let(:stemcell) { { "name" => name, "version" => version } }
 
   context "given a normal stemcell" do
-    let(:light) { nil }
     let(:name) { "bosh-warden-boshlite-ubuntu-trusty-go_agent" }
-    let(:file_name) { "bosh-stemcell-3-warden-boshlite-ubuntu-trusty-go_agent.tgz" }
     let(:version) { 3 }
 
     describe "#name_version" do
       its(:name_version) { is_expected.to eq "#{name}/#{version}" }
     end
 
-    describe "#file_name" do
-      its(:file_name) { is_expected.to eq file_name }
-    end
-
-    describe "#downloaded?" do
-      before do
-        expect(File).to receive(:exist?).with(/\/#{file_name}/).and_return(true)
-      end
-      its(:downloaded?) { is_expected.to eq true }
-    end
-
     describe "attr readers" do
-      let(:file) { "#{stemcells_dir}/#{file_name}" }
-      %w(name version file).each do |attr|
-        its(attr.to_sym) { is_expected.to eq eval(attr) }
-      end
-    end
-  end
-
-  context "given a light stemcell" do
-    let(:light) { true }
-    let(:name) { "bosh-aws-xen-hvm-ubuntu-trusty-go_agent" }
-    let(:file_name) { "light-bosh-stemcell-3143-aws-xen-hvm-ubuntu-trusty-go_agent.tgz" }
-    let(:version) { 3143 }
-
-    describe "#name_version" do
-      its(:name_version) { is_expected.to eq "#{name}/#{version}" }
-    end
-
-    describe "#file_name" do
-      its(:file_name) { is_expected.to eq file_name }
-    end
-
-    describe "#downloaded?" do
-      before do
-        expect(File).to receive(:exist?).with(/\/#{file_name}/).and_return(true)
-      end
-      its(:downloaded?) { is_expected.to eq true }
-    end
-
-    describe "attr readers" do
-      let(:file) { "#{stemcells_dir}/#{file_name}" }
-      %w(name version file).each do |attr|
+      %w(name version).each do |attr|
         its(attr.to_sym) { is_expected.to eq eval(attr) }
       end
     end


### PR DESCRIPTION
proposed patch for issue number #84

the first commit adds the new functionality, the second commit cleans up the no longer needed methods for locally downloading stemcells.