### PR TITLE
Use new bosh.io URL to upload stemcells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ tmp
 *.generated_manifests
 *.DS_Store
 /spec/assets/manifests-repo/.releases/*
+.idea
+

--- a/lib/bosh/cli/commands/prepare.rb
+++ b/lib/bosh/cli/commands/prepare.rb
@@ -84,7 +84,7 @@ module Bosh::Cli::Command
       unless stemcell.downloaded?
         err "Stemcell not available offline: #{stemcell.file_name}" if offline?
         say "Downloading '#{stemcell.name_version.make_green}'"
-        stemcell_download(stemcell.file_name)
+        stemcell_download(stemcell)
       end
       say "Uploading '#{stemcell.name_version.make_green}'"
       stemcell_upload(stemcell.file)

--- a/lib/bosh/workspace/helpers/stemcell_helper.rb
+++ b/lib/bosh/workspace/helpers/stemcell_helper.rb
@@ -41,7 +41,7 @@ module Bosh::Workspace
 
     def download_stemcell_from_bosh_io(stemcell)
 
-      url=sprintf("https://bosh.io/d/stemcells/%s?v=%s", stemcell.name, stemcell.version)
+      url = "https://bosh.io/d/stemcells/#{stemcell.name}?v=#{stemcell.version}"
 
       response = HTTPClient.new.head(url)
 

--- a/lib/bosh/workspace/helpers/stemcell_helper.rb
+++ b/lib/bosh/workspace/helpers/stemcell_helper.rb
@@ -1,12 +1,15 @@
+require 'httpclient'
+require 'cli/download_with_progress'
+
 module Bosh::Workspace
   module StemcellHelper
     include ProjectDeploymentHelper
 
-    def stemcell_download(stemcell_name)
+    def stemcell_download(stemcell)
       Dir.chdir(stemcells_dir) do
-        say "Downloading stemcell '#{stemcell_name}'"
+        say "Downloading stemcell '#{stemcell.name}' version '#{stemcell.version}'"
         nl
-        stemcell_cmd.download_public(stemcell_name)
+        download_stemcell_from_bosh_io(stemcell)
       end
     end
 
@@ -36,10 +39,38 @@ module Bosh::Workspace
       end
     end
 
+    def download_stemcell_from_bosh_io(stemcell)
+
+      url=sprintf("https://bosh.io/d/stemcells/%s?v=%s", stemcell.name, stemcell.version)
+
+      response = HTTPClient.new.head(url)
+
+      if response.status == 302
+        location = response.header['location'][0]
+        response2 = HTTPClient.new.head(location)
+
+        if response2.status == 200
+          size = response2.header['Content-Length'][0]
+        else
+          say("HTTP #{response2.status} : #{location}".make_red)
+          say(" - redirected from: : #{url}".make_red)
+          return
+        end
+      else
+        say("HTTP #{response.status} : #{url} (expecting 302 - redirect)".make_red)
+        return
+      end
+
+      download_with_progress = Bosh::Cli::DownloadWithProgress.new(location, size.to_i)
+      download_with_progress.perform
+    end
+
     private
 
     def stemcell_cmd
       @stemcell_cmd ||= Bosh::Cli::Command::Stemcell.new
     end
+
   end
+
 end

--- a/spec/commands/prepare_spec.rb
+++ b/spec/commands/prepare_spec.rb
@@ -139,7 +139,7 @@ describe Bosh::Cli::Command::Prepare do
           let(:stemcell_downloaded) { false }
 
           it "downloads and uploads the stemcell" do
-            expect(command).to receive(:stemcell_download).with(stemcell.file_name)
+            expect(command).to receive(:stemcell_download).with(stemcell)
             expect(command).to receive(:stemcell_upload).with(stemcell.file)
             command.prepare
           end

--- a/spec/helpers/stemcell_helper_spec.rb
+++ b/spec/helpers/stemcell_helper_spec.rb
@@ -23,12 +23,13 @@ describe Bosh::Workspace::StemcellHelper do
     end
 
     describe "#stemcell_download" do
-      let(:name) { "foo" }
-      subject { stemcell_helper.stemcell_download(name) }
+      let(:stemcell) { instance_double("Bosh::Workspace::Stemcell", :name => "foo", :version => "1") }
+
+      subject { stemcell_helper.stemcell_download(stemcell) }
 
       it "downloads stemcell" do
         expect(Dir).to receive(:chdir).and_yield
-        expect(stemcell_cmd).to receive(:download_public).with(name)
+        expect(stemcell_helper).to receive(:download_stemcell_from_bosh_io).with(stemcell)
         subject
       end
     end


### PR DESCRIPTION
'bosh prepare deployment' no longer works for
newer stemcells because it uses deprecated
'bosh public stemcells' which in turn uses outdated
stemcell URLs.