### PR TITLE
Added support for symbolic git references in the 'ref:' attribute of releases

### DIFF
--- a/lib/bosh/workspace/release.rb
+++ b/lib/bosh/workspace/release.rb
@@ -39,7 +39,15 @@ module Bosh::Workspace
     end
 
     def ref
-      @ref && ( repo.ref(@ref).resolve.target.oid || repo.lookup(@ref).oid )
+      if !@ref then
+        return nil
+      end
+      begin
+        oid = repo.ref(@ref).resolve.target.oid
+      rescue
+        oid = repo.lookup(@ref).oid
+      end
+      return oid
     end
 
     def release_dir

--- a/lib/bosh/workspace/release.rb
+++ b/lib/bosh/workspace/release.rb
@@ -39,7 +39,7 @@ module Bosh::Workspace
     end
 
     def ref
-      @ref && repo.lookup(@ref).oid
+      @ref && ( repo.ref(@ref).resolve.target.oid || repo.lookup(@ref).oid )
     end
 
     def release_dir

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -521,6 +521,8 @@ module Bosh::Workspace
           expect(Rugged::Repository).to receive(:new)
             .and_return(repository).at_least(:once)
           expect(repository).to receive(:fetch)
+          expect(repository).to receive(:ref)
+            .and_raise(Rugged::ReferenceError)
           expect(repository).to receive(:references) do
             { 'refs/remotes/origin/HEAD' =>
               double(resolve: double(target_id: :oid)) }


### PR DESCRIPTION
Working with bosh-workspace 0.9.10, I figured out that the 'ref:' attribute only accepts “ugly” OID hashes, where it could either accept “nice” symbolic tags.

So I'm submitting this patch, in order to allow specifying tags like `refs/tags/v25.1` (the latest `cf-mysql` version indeed!) and not just OID hashes like `4c9e18c91bba56dd6700b582ed16e3a4ca647e77`.

Cheers!