### PR TITLE
Fix the « undefined method 'target' » error

### DIFF
--- a/lib/bosh/workspace/release.rb
+++ b/lib/bosh/workspace/release.rb
@@ -40,8 +40,11 @@ module Bosh::Workspace
 
     def ref
       return nil unless @ref
-      return repo.ref(@ref).target.target.oid if
-        Rugged::Reference.valid_name?(@ref) && repo.ref(@ref)
+      if Rugged::Reference.valid_name?(@ref) && repo.ref(@ref)
+        commit_ref = repo.ref(@ref).target
+        commit_ref = commit_ref.target unless commit_ref.is_a?(Rugged::Commit)
+        return commit_ref.oid
+      end
       repo.lookup(@ref).oid
     end
 

--- a/spec/release_spec.rb
+++ b/spec/release_spec.rb
@@ -241,7 +241,7 @@ module Bosh::Workspace
       end
     end
 
-    context "given a release with deprecated structure within 'releases' folder" do
+    context "given a release with deprecated structure within 'releases' folder:" do
       let(:repo) { extracted_asset_dir("foo", "foo-boshrelease-repo.zip") }
 
       describe "#update_repo" do
@@ -322,6 +322,7 @@ module Bosh::Workspace
           let(:release_data) do
             {"name" => name, "version" => "latest", "ref" => "refs/tags/v8", "git" => repo}
           end
+          let(:release) { load_release(release_data, {}, true) }
 
           it "checks out repo" do
 
@@ -334,6 +335,7 @@ module Bosh::Workspace
           let(:release_data) do
             {"name" => name, "version" => "9.1", "ref" => "refs/tags/v9.1", "git" => repo}
           end
+          let(:release) { load_release(release_data, {}, true) }
 
           it "checks out repo" do
             release.update_repo


### PR DESCRIPTION
Following investigations made in #116, here is a patch to support the case were `repo.ref(@ref).target` is already a commit object, instead of a tag annotation object (whose target object ID we are interested in).

Could you guys see if you can add some test to cover this case please?

I'm afraid I already spend way too many hours on this issue for today.. :( Thanks!

Cheers